### PR TITLE
feat: add line number to lint for noarch and runtime dependencies

### DIFF
--- a/conda_smithy/linter/lints.py
+++ b/conda_smithy/linter/lints.py
@@ -363,7 +363,7 @@ def lint_noarch_and_runtime_dependencies(
         noarch_platforms = len(forge_yaml.get("noarch_platforms", [])) > 1
         with open(meta_fname, encoding="utf-8") as fh:
             in_runreqs = False
-            for line in fh:
+            for line_number, line in enumerate(fh):
                 line_s = line.strip()
                 if line_s == "host:" or line_s == "run:":
                     in_runreqs = True
@@ -373,7 +373,7 @@ def lint_noarch_and_runtime_dependencies(
                     lints.append(
                         "`noarch` packages can't have skips with selectors. If "
                         "the selectors are necessary, please remove "
-                        f"`noarch: {noarch_value}`."
+                        f"`noarch: {noarch_value}` on line {line_number}."
                     )
                     break
                 if in_runreqs:
@@ -388,7 +388,7 @@ def lint_noarch_and_runtime_dependencies(
                         lints.append(
                             "`noarch` packages can't have selectors. If "
                             "the selectors are necessary, please remove "
-                            f"`noarch: {noarch_value}`."
+                            f"`noarch: {noarch_value}` on line {line_number}."
                         )
                         break
 


### PR DESCRIPTION
I wanted to get feedback on this PR, in particularly I would find it useful if the linter would tell you _which_ line the linting issue occurs on.  While this PR only address a single lint I'm interested in (since I had trouble locating where the selector was in the recipe), I want feedback if a larger PR would be welcome that would describe the line number various lint issues occur on?



<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a ``news`` entry
* [ ] Regenerated schema JSON if schema altered (`python conda_smithy/schema.py`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
